### PR TITLE
Fixing Decoding Process for Float Type

### DIFF
--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -94,7 +94,10 @@ private extension _MsgPackDecoder {
             return nil
         }
         if case let .literal(.str(v)) = value {
-            return String(data: v, encoding: .utf8)
+            guard let s = String(data: v, encoding: .utf8) else {
+                throw MsgPackDecodingError.dataCorrupted
+            }
+            return s
         }
 
         throw DecodingError.typeMismatch(type, DecodingError.Context(
@@ -182,7 +185,10 @@ extension _MsgPackDecoder {
         }
         if let type = type as? MsgPackDecodable.Type {
             let value = try unwrapMsgPackDecodable(as: type)
-            return value as! T
+            guard let ret = value as? T else {
+                throw MsgPackDecodingError.dataCorrupted
+            }
+            return ret
         }
         if T.self is _MsgPackDictionaryDecodableMarker.Type {
             try checkDictionay(as: T.self)
@@ -252,59 +258,101 @@ private struct _MsgPackSingleValueDecodingContainer: SingleValueDecodingContaine
     }
 
     func decode(_: Bool.Type) throws -> Bool {
-        try decoder.unbox(value, as: Bool.self)!
+        guard let b = try decoder.unbox(value, as: Bool.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return b
     }
 
     func decode(_ type: String.Type) throws -> String {
-        try decoder.unbox(value, as: type)!
+        guard let s = try decoder.unbox(value, as: String.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return s
     }
 
     func decode(_ type: Double.Type) throws -> Double {
-        try decoder.unboxFloat(value, as: type)!
+        guard let d = try decoder.unboxFloat(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return d
     }
 
     func decode(_ type: Float.Type) throws -> Float {
-        try decoder.unboxFloat(value, as: type)!
+        guard let f = try decoder.unboxFloat(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return f
     }
 
     func decode(_ type: Int.Type) throws -> Int {
-        try decoder.unboxInt(value, as: type)!
+        guard let i = try decoder.unboxInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: Int8.Type) throws -> Int8 {
-        try decoder.unboxInt(value, as: type)!
+        guard let i = try decoder.unboxInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: Int16.Type) throws -> Int16 {
-        try decoder.unboxInt(value, as: type)!
+        guard let i = try decoder.unboxInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: Int32.Type) throws -> Int32 {
-        try decoder.unboxInt(value, as: type)!
+        guard let i = try decoder.unboxInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: Int64.Type) throws -> Int64 {
-        try decoder.unboxInt(value, as: type)!
+        guard let i = try decoder.unboxInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: UInt.Type) throws -> UInt {
-        try decoder.unboxUInt(value, as: type)!
+        guard let i = try decoder.unboxUInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: UInt8.Type) throws -> UInt8 {
-        try decoder.unboxUInt(value, as: type)!
+        guard let i = try decoder.unboxUInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: UInt16.Type) throws -> UInt16 {
-        try decoder.unboxUInt(value, as: type)!
+        guard let i = try decoder.unboxUInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: UInt32.Type) throws -> UInt32 {
-        try decoder.unboxUInt(value, as: type)!
+        guard let i = try decoder.unboxUInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode(_ type: UInt64.Type) throws -> UInt64 {
-        try decoder.unboxUInt(value, as: type)!
+        guard let i = try decoder.unboxUInt(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return i
     }
 
     func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
@@ -365,13 +413,19 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     mutating func decode(_: Bool.Type) throws -> Bool {
         let value = try getNextValue(ofType: String.self)
         currentIndex += 1
-        return try decoder.unbox(value, as: Bool.self)!
+        guard let r = try decoder.unbox(value, as: Bool.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return r
     }
 
     mutating func decode(_: String.Type) throws -> String {
         let value = try getNextValue(ofType: String.self)
         currentIndex += 1
-        return try decoder.unbox(value, as: String.self)!
+        guard let s = try decoder.unbox(value, as: String.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return s
     }
 
     mutating func decode(_: Double.Type) throws -> Double {
@@ -470,7 +524,9 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     @inline(__always)
     private mutating func decodeUInt<T: UnsignedInteger>(as _: T.Type) throws -> T {
         let value = try getNextValue(ofType: T.self)
-        let result = try decoder.unboxUInt(value, as: T.self)!
+        guard let result = try decoder.unboxUInt(value, as: T.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
         currentIndex += 1
         return result
     }
@@ -478,7 +534,9 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     @inline(__always)
     private mutating func decodeInt<T: SignedInteger>(as _: T.Type) throws -> T {
         let value = try getNextValue(ofType: T.self)
-        let result = try decoder.unboxInt(value, as: T.self)!
+        guard let result = try decoder.unboxInt(value, as: T.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
         currentIndex += 1
         return result
     }
@@ -486,7 +544,9 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     @inline(__always)
     private mutating func decodeFloat<T: BinaryFloatingPoint & DataNumber>(as _: T.Type) throws -> T {
         let value = try getNextValue(ofType: T.self)
-        let result = try decoder.unboxFloat(value, as: T.self)!
+        guard let result = try decoder.unboxFloat(value, as: T.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
         currentIndex += 1
         return result
     }
@@ -525,12 +585,18 @@ private struct MsgPackKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContain
 
     func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
         let value = try getValue(forKey: key)
-        return try decoder.unbox(value, as: type)!
+        guard let v = try decoder.unbox(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return v
     }
 
     func decode(_ type: String.Type, forKey key: Key) throws -> String {
         let value = try getValue(forKey: key)
-        return try decoder.unbox(value, as: type)!
+        guard let r = try decoder.unbox(value, as: type) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return r
     }
 
     func decode(_: Double.Type, forKey key: Key) throws -> Double {
@@ -627,7 +693,10 @@ private struct MsgPackKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContain
     @inline(__always)
     private func decodeFloat<T: BinaryFloatingPoint & DataNumber>(key: K) throws -> T {
         let value = try getValue(forKey: key)
-        return try decoder.unboxFloat(value, as: T.self)!
+        guard let r = try decoder.unboxFloat(value, as: T.self) else {
+            throw MsgPackDecodingError.dataCorrupted
+        }
+        return r
     }
 
     @inline(__always)

--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -124,7 +124,7 @@ private extension _MsgPackDecoder {
             debugDescription: "Expected to decode \(type) but found \(value.debugDataTypeDescription) instead."
         ))
     }
-
+    
     func unboxInt<T: SignedInteger>(_ value: MsgPackValue, as type: T.Type) throws -> T? {
         if value == .Nil {
             return nil
@@ -132,9 +132,23 @@ private extension _MsgPackDecoder {
         if case let .literal(vv) = value {
             switch vv {
             case .uint:
-                return T(try bigEndianUInt(vv.data))
+                let v = try bigEndianUInt(vv.data)
+                guard let r=T(exactly:v ) else {
+                    throw DecodingError.typeMismatch(type, DecodingError.Context(
+                        codingPath: codingPath,
+                        debugDescription: "Expected to decode \(type) but found \(v)(\(value.debugDataTypeDescription)) instead."
+                    ))
+                }
+                return r
             case .int:
-                return T(try bigEndianInt(vv.data))
+                let v = try bigEndianInt(vv.data)
+                guard let r=T(exactly:v ) else {
+                    throw DecodingError.typeMismatch(type, DecodingError.Context(
+                        codingPath: codingPath,
+                        debugDescription: "Expected to decode \(type) but found \(v)(\(value.debugDataTypeDescription)) instead."
+                    ))
+                }
+                return r
             default:
                 break
             }

--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -107,10 +107,18 @@ private extension _MsgPackDecoder {
         if value == .Nil {
             return nil
         }
-        if case let .literal(.float(v)) = value {
-            return try type.init(data: v)
+        if case let .literal(v) = value {
+            switch v {
+            case .float:
+                return try type.init(data: v.data)
+            case .uint:
+                return T(try bigEndianUInt(v.data))
+            case .int:
+                return T(try bigEndianInt(v.data))
+            default:
+                break
+            }
         }
-
         throw DecodingError.typeMismatch(type, DecodingError.Context(
             codingPath: codingPath,
             debugDescription: "Expected to decode \(type) but found \(value.debugDataTypeDescription) instead."

--- a/Tests/SwiftMsgpackTests/DecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/DecodeTests.swift
@@ -184,6 +184,26 @@ final class DecodeTests: XCTestCase {
             // pass, error expected
         }
     }
+
+    func testDecodeRandomBytes() throws {
+        let srcText = "82a3666f6fa3626172a362617a9701a6e381bbe381928090cbe947e38a1b3f4bd5cb693e6769f422036ccf2762762762762762"
+        for i in 0..<1000 {
+            do {
+                var bin = Data(hex:srcText)
+                let ix = i % bin.count
+                let noise = UInt8(1 + (i*7+13) % 255)
+                bin[ix] ^= noise
+                let _ = try decoder.decode(AnyCodable.self, from:bin)
+            }
+            //It is ok if the decoder reports an error without crashing
+            catch is MsgPackDecodingError {
+                print( "caught: i=", i )
+            }
+            catch is DecodingError {
+                print( "caught: i=", i )
+            }
+        }
+    }
 }
 
 private struct AnyCodingKeys: CodingKey {

--- a/Tests/SwiftMsgpackTests/DecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/DecodeTests.swift
@@ -165,6 +165,25 @@ final class DecodeTests: XCTestCase {
         XCTAssertEqual(dict.count, 1)
         XCTAssertEqual(dict["key"], AnyCodable(0x34))
     }
+
+    func testDecodeMalformedString() throws {
+        let s = "gaFzgaZzdHJpbmfZOUluIHRvdGFsIGRhcmtuZXNzLCBvciBpbiBhIHZlcnkgbGFyZ2Ugcm9vbSwgdmVyeSBxdWlldGx54oCm"
+        guard let sd = s.data(using: .ascii) else {
+            XCTFail("couldn't encode string as ascii")
+            return
+        }
+        guard let d = Data(base64Encoded: sd) else {
+            XCTFail("couldn't decode base64 data")
+            return
+        }
+        let decoder = MsgPackDecoder()
+        do {
+            let v = try decoder.decode(MalformedStringTest.self, from: d)
+            XCTFail("expected failure, decoded \(v)")
+        } catch {
+            // pass, error expected
+        }
+    }
 }
 
 private struct AnyCodingKeys: CodingKey {
@@ -432,5 +451,13 @@ private struct Pairs: Decodable, Equatable {
             b.append(.init(X: x, Y: y))
         }
         a = b
+    }
+}
+
+private enum MalformedStringTest: Codable {
+    case S(s: String)
+
+    enum CodingKeys: String, CodingKey {
+        case S = "s"
     }
 }

--- a/Tests/SwiftMsgpackTests/DecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/DecodeTests.swift
@@ -81,8 +81,16 @@ final class DecodeTests: XCTestCase {
             try t(in: "e0", type: Int32.self, out: -0x20)
             try t(in: "e0", type: Int64.self, out: -0x20)
             try t(in: "e0", type: Int.self, out: -0x20)
+            try t(in: "e0", type: Float.self, out: -0x20)
+            try t(in: "e0", type: Double.self, out: -0x20)
             try t(in: "cc80", type: Int32.self, out: Int32(Int8.max) + 1)
             try t(in: "ce80000000", type: Int64.self, out: Int64(Int32.max) + 1)
+            try t(in: "ce80000000", type: Float.self, out: Float(Int32.max)) // "+1" has no effect.
+            try t(in: "ce80000000", type: Double.self, out: Double(Int32.max) + 1)
+            try t(in: "cfffffffffffffffff", type: UInt64.self, out: UInt64.max )
+            try t(in: "cfffffffffffffffff", type: Float.self, out: Float(UInt64.max))
+            try t(in: "cfffffffffffffffff", type: Double.self, out: Double(UInt64.max))
+            
             // UnkeyedDecodingContainer
             try t(in: "dc0003a3616263a378797aa3646464", type: SS.self, out: SS(a: ["abc", "xyz", "ddd"]))
             try t(in: "921234", type: UIS.self, out: UIS(a: [0x12, 0x34]))
@@ -120,6 +128,13 @@ final class DecodeTests: XCTestCase {
             try t(in: "c3", type: String.self, out: "", errorType: DecodingError.self)
             try t(in: "c3", type: Data.self, out: .init(), errorType: DecodingError.self)
             try t(in: "7f", type: Bool.self, out: true, errorType: DecodingError.self)
+            // overflow
+            try t(in: "ce80000000", type: Int16.self, out: 0 , errorType: DecodingError.self)
+            try t(in: "cfffffffffffffffff", type: Int64.self, out: Int64.max, errorType: DecodingError.self)
+            try t(in: "e0", type: UInt8.self, out: 0, errorType: DecodingError.self)
+            try t(in: "e0", type: UInt16.self, out: 0, errorType: DecodingError.self)
+            try t(in: "e0", type: UInt32.self, out: 0, errorType: DecodingError.self)
+            try t(in: "e0", type: UInt64.self, out: 0, errorType: DecodingError.self)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/SwiftMsgpackTests/DecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/DecodeTests.swift
@@ -11,12 +11,13 @@ final class DecodeTests: XCTestCase {
                 XCTFail()
                 return
             }
-            XCTAssertEqual(actual, out)
+            XCTAssertEqual(actual, out, String(format:"input: %@", input))
         } catch {
             guard let errorType = errorType else {
+                XCTFail(String(format:"input: %@, error:%@", input, error.localizedDescription ))
                 throw error
             }
-            XCTAssertTrue(type(of: error) == errorType)
+            XCTAssertTrue(type(of: error) == errorType, String(format:"input: %@", input))
         }
     }
 
@@ -51,6 +52,7 @@ final class DecodeTests: XCTestCase {
             try t(in: "c403123456", type: Data.self, out: Data([0x12, 0x34, 0x56]))
             try t(in: "c50003123456", type: Data.self, out: Data([0x12, 0x34, 0x56]))
             try t(in: "c600000003123456", type: Data.self, out: Data([0x12, 0x34, 0x56]))
+            try t(in: "10", type: Float.self, out: 16.0)
             try t(in: "ca4015c28f", type: Float.self, out: 2.34)
             try t(in: "cb4002b851eb851eb8", type: Double.self, out: 2.34)
             try t(in: "cc80", type: UInt8.self, out: 0x80)


### PR DESCRIPTION
- JavaScript などからくる MesagePack には、浮動小数点数があるべき場所に整数がある場合があります。そのような場合でもデコードできるようにしました。
- [CSM さんの変更](https://github.com/nnabeyang/swift-msgpack/commit/2127b5af96728d47fc90a6095ee8847987120855#diff-106bf5431bf830832820e1e9b15460710e9ee77b8ee516b98afa93e3e810b0a4)（UTF-8 として受け入れられない文字列の場合にエラー報告する）を入れました。
- 無効なバイト列の場合にクラッシュする場合がありましたが、クラッシュせずに例外を返すようにしました。

という変更です。

※ 私は Swift 歴数週間なので、書き方など色々おかしいかもしれません。
