### PR TITLE
Add GitHub Actions workflow to run Swift Package tests on macOS, iOS, and Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,77 @@
+name: Swift Package Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  test-apple-platforms:
+    name: Test on Apple Platforms (Xcode 16.2)
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [iOS, macOS]
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Xcode 16.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+      
+      - name: Run xcodebuild tests
+        run: |
+          if [ "${{ matrix.target }}" = "iOS" ]; then
+            DESTINATION="platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2"
+          else
+            DESTINATION="platform=macOS"
+          fi
+          
+          echo "Using destination: $DESTINATION"
+          xcodebuild clean test \
+            -scheme swift-msgpack-Package \
+            -destination "$DESTINATION" \
+            | xcpretty
+
+  test-linux:
+    name: Test on Linux
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        swift_version: ["6.0", "6.1"]
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Swift ${{ matrix.swift_version }}
+        run: |
+          SWIFT_VERSION=${{ matrix.swift_version }}
+          
+          case "$SWIFT_VERSION" in
+            "6.0")
+              SWIFT_URL="https://download.swift.org/swift-6.0-release/ubuntu2204/swift-6.0-RELEASE/swift-6.0-RELEASE-ubuntu22.04.tar.gz"
+              ;;
+            "6.1")
+              SWIFT_URL="https://download.swift.org/swift-6.1-release/ubuntu2204/swift-6.1-RELEASE/swift-6.1-RELEASE-ubuntu22.04.tar.gz"
+              ;;
+            *)
+              echo "Error: Unsupported Swift version."
+              exit 1
+              ;;
+          esac
+          
+          echo "Downloading Swift from $SWIFT_URL"
+          wget "$SWIFT_URL"
+          tar xzf "swift-${SWIFT_VERSION}-RELEASE-ubuntu22.04.tar.gz"
+          
+          export PATH="/home/runner/work/swift-${SWIFT_VERSION}-RELEASE-ubuntu22.04/usr/bin:$PATH"
+          
+          swift --version
+
+      - name: Run SwiftPM tests
+        run: swift test


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically run tests for the Swift package on multiple platforms:

- Apple platforms (macOS and iOS) using Xcode 16.2
- Linux (Ubuntu 22.04) with Swift 6.0 and 6.1
