### PR TITLE
Support configuration-aware encoding/decoding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "swift-msgpack",
-    platforms: [.macOS(.v10_15), .iOS(.v13)],
+    platforms: [.macOS(.v12), .iOS(.v15)],
     products: [
         .library(
             name: "SwiftMsgpack",

--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -25,6 +25,28 @@ open class MsgPackDecoder {
             }
         }
     }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    open func decode<T: DecodableWithConfiguration>(_ type: T.Type, from data: Data, configuration: T.DecodingConfiguration) throws -> T {
+        try data.withUnsafeBytes {
+            let scanner: MsgPackScanner = .init(ptr: $0.baseAddress!, count: $0.count)
+            let value = scanner.scan()
+            let decoder: _MsgPackDecoder = .init(from: value)
+            do {
+                return try decoder.unwrap(as: T.self, configuration: configuration)
+            } catch {
+                if let error = error as? MsgPackDecodingError {
+                    throw error.asDecodingError(type, codingPath: [])
+                }
+                throw error
+            }
+        }
+    }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    open func decode<T, C>(_ type: T.Type, from data: Data, configuration: C.Type) throws -> T where T: DecodableWithConfiguration, C: DecodingConfigurationProviding, T.DecodingConfiguration == C.DecodingConfiguration {
+        try decode(type, from: data, configuration: C.decodingConfiguration)
+    }
 }
 
 public protocol MsgPackDecodable: Decodable {
@@ -196,6 +218,10 @@ extension _MsgPackDecoder {
             try checkArray(as: T.self)
         }
         return try T(from: self)
+    }
+
+    func unwrap<T: DecodableWithConfiguration>(as type: T.Type, configuration: T.DecodingConfiguration) throws -> T {
+        try type.init(from: self, configuration: configuration)
     }
 
     func unwrapData() throws -> Data {

--- a/Sources/SwiftMsgpack/MsgPackEncoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackEncoder.swift
@@ -28,9 +28,30 @@ open class MsgPackEncoder {
         return Data(bytes)
     }
 
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    open func encode<T: EncodableWithConfiguration>(_ value: T, configuration: T.EncodingConfiguration) throws -> Data {
+        let value: MsgPackEncodedValue = try encodeAsMsgPackValue(value, configuration: configuration)
+        let writer = MsgPackValue.Writer()
+        let bytes = writer.writeValue(value)
+        return Data(bytes)
+    }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    open func encode<T, C>(_ value: T, configuration: C.Type) throws -> Data where T: EncodableWithConfiguration, C: EncodingConfigurationProviding, T.EncodingConfiguration == C.EncodingConfiguration {
+        try encode(value, configuration: C.encodingConfiguration)
+    }
+
     func encodeAsMsgPackValue<T: Encodable>(_ value: T) throws -> MsgPackEncodedValue {
         let encoder = _MsgPackEncoder(codingPath: [], options: options)
         guard let result = try encoder.wrapEncodable(value, for: CodingKey?.none) else {
+            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
+        }
+        return result
+    }
+
+    func encodeAsMsgPackValue<T: EncodableWithConfiguration>(_ value: T, configuration: T.EncodingConfiguration) throws -> MsgPackEncodedValue {
+        let encoder = _MsgPackEncoder(codingPath: [], options: options)
+        guard let result = try encoder.wrapEncodable(value, configuration: configuration, for: CodingKey?.none) else {
             throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
         }
         return result
@@ -440,6 +461,29 @@ private extension _SpecialTreatmentEncoder {
             return try wrapMsgPackEncodable(msgPack, for: additionalKey)
         default:
             try encodable.encode(to: encoder)
+        }
+
+        if let anyCodable = encodable as? AnyCodable {
+            if anyCodable.base as? _MsgPackDictionaryEncodableMarker != nil {
+                return encoder.value?.asMap()
+            }
+        } else {
+            if (encodable as? _MsgPackDictionaryEncodableMarker) != nil {
+                return encoder.value?.asMap()
+            }
+        }
+        return encoder.value
+    }
+
+    func wrapEncodable<E: EncodableWithConfiguration>(_ encodable: E, configuration: E.EncodingConfiguration, for additionalKey: CodingKey?) throws -> MsgPackEncodedValue? {
+        let encoder = getEncoder(for: additionalKey)
+        switch encodable {
+        case let data as Data:
+            return try wrapData(data, for: additionalKey)
+        case let msgPack as MsgPackEncodable:
+            return try wrapMsgPackEncodable(msgPack, for: additionalKey)
+        default:
+            try encodable.encode(to: encoder, configuration: configuration)
         }
 
         if let anyCodable = encodable as? AnyCodable {

--- a/Tests/SwiftMsgpackTests/DecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/DecodeTests.swift
@@ -166,6 +166,37 @@ final class DecodeTests: XCTestCase {
         t(in: "d3ffffffb494cb5434", type: Int128.self, out: -0x4B_6B34_ABCC)
         t(in: "82a158d38000000000000000a159d37fffffffffffffff", type: Pair<Int128>.self, out: Pair(X: Int128(Int64.min), Y: Int128(Int64.max)))
     }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    func testWithConfigurationAppliesConfiguration() throws {
+        let encoder = MsgPackEncoder()
+        let original = 30
+        let data = try encoder.encode(original)
+
+        let decoder = MsgPackDecoder()
+        let decoded = try decoder.decode(
+            ConfiguredInt.self,
+            from: data,
+            configuration: TestConfig(multiplier: 3)
+        )
+
+        XCTAssertEqual(decoded, ConfiguredInt(value: 10))
+    }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    func testWithConfigurationProvider() throws {
+        let encoder = MsgPackEncoder()
+        let data = try encoder.encode(100)
+
+        let decoder = MsgPackDecoder()
+        let decoded = try decoder.decode(
+            ConfiguredInt.self,
+            from: data,
+            configuration: TestConfigProvider.self
+        )
+
+        XCTAssertEqual(decoded, ConfiguredInt(value: 50))
+    }
 }
 
 private struct AnyCodingKeys: CodingKey {
@@ -428,5 +459,39 @@ private struct Pairs: Decodable, Equatable {
             b.append(.init(X: x, Y: y))
         }
         a = b
+    }
+}
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+struct TestConfig: Sendable {
+    let multiplier: Int
+}
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+enum TestConfigProvider: EncodingConfigurationProviding, DecodingConfigurationProviding {
+    static let encodingConfiguration = TestConfig(multiplier: 2)
+    static let decodingConfiguration = TestConfig(multiplier: 2)
+}
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+struct ConfiguredInt: CodableWithConfiguration, Equatable {
+    typealias EncodingConfiguration = TestConfig
+    typealias DecodingConfiguration = TestConfig
+
+    let value: Int
+
+    init(value: Int) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder, configuration: DecodingConfiguration) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(Int.self)
+        value = raw / configuration.multiplier
+    }
+
+    func encode(to encoder: Encoder, configuration: EncodingConfiguration) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value * configuration.multiplier)
     }
 }

--- a/Tests/SwiftMsgpackTests/EncodeTests.swift
+++ b/Tests/SwiftMsgpackTests/EncodeTests.swift
@@ -85,6 +85,24 @@ final class EncodeTests: XCTestCase {
         t(in: Int128(Int64.min) - 1, type: Int128.self, out: "", errorType: EncodingError.self)
         t(in: Int128(Int64.max) + 1, type: Int128.self, out: "", errorType: EncodingError.self)
     }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    func testWithConfiguration_appliesConfiguration() throws {
+        let encoder = MsgPackEncoder()
+        let value = ConfiguredInt(value: 21)
+
+        let data = try encoder.encode(value, configuration: TestConfig(multiplier: 2))
+        XCTAssertEqual(data.hexDescription, "2a")
+    }
+
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    func testWithConfigurationProvider() throws {
+        let encoder = MsgPackEncoder()
+        let value = ConfiguredInt(value: 10)
+
+        let data = try encoder.encode(value, configuration: TestConfigProvider.self)
+        XCTAssertEqual(data.hexDescription, "14")
+    }
 }
 
 extension Data {


### PR DESCRIPTION
This PR introduces support for configuration-aware encoding and decoding in the SwiftMsgpack encoder and decoder APIs.