### PR TITLE
ci: gate workflow on path changes and switch Linux to official Swift containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,34 +4,61 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 jobs:
+  # Detect whether this change touches code/CI/formatter files.
+  # When only docs (e.g. README.md) change, downstream test jobs are skipped
+  # and `ci-required` reports success on their behalf.
+  # If you add a new top-level directory that affects build or tests,
+  # append it to the `code` filter below.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'some'
+          filters: |
+            code:
+              - 'Sources/**'
+              - 'Tests/**'
+              - 'Example/**'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.github/workflows/**'
+              - '.swiftformat'
+              - 'format.sh'
+
   test-apple-platforms:
-    name: Test on Apple Platforms (Xcode 16.2)
-    runs-on: macos-latest
+    needs: changes
+    if: >-
+      needs.changes.outputs.code == 'true'
+      || github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
+    name: Test on Apple Platforms (Xcode 26.5)
+    runs-on: macOS-26
+    timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app
     strategy:
       matrix:
         target: [iOS, macOS]
-    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Use Xcode 16.2
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.2'
-      
-      - name: Run xcodebuild tests
+      - name: Test platform ${{ matrix.target }}
         run: |
           if [ "${{ matrix.target }}" = "iOS" ]; then
-            DESTINATION="platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2"
+            DESTINATION="platform=iOS Simulator,name=iPhone 17e,OS=26.5"
           else
             DESTINATION="platform=macOS"
           fi
-          
+
           echo "Using destination: $DESTINATION"
           xcodebuild clean test \
             -scheme swift-msgpack-Package \
@@ -39,39 +66,47 @@ jobs:
             | xcpretty
 
   test-linux:
-    name: Test on Linux
-    runs-on: ubuntu-22.04
+    needs: changes
+    if: >-
+      needs.changes.outputs.code == 'true'
+      || github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
+    name: Test on Linux (Swift ${{ matrix.swift_version }})
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container_image }}
     strategy:
       matrix:
-        swift_version: ["6.0", "6.1"]
-    
+        include:
+          - swift_version: "6.1"
+            container_image: "swift:6.1-noble"
+          - swift_version: "6.3.2"
+            container_image: "swift:6.3.2-noble"
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install Swift ${{ matrix.swift_version }}
-        run: |
-          SWIFT_VERSION=${{ matrix.swift_version }}
-          
-          case "$SWIFT_VERSION" in
-            "6.0")
-              SWIFT_URL="https://download.swift.org/swift-6.0-release/ubuntu2204/swift-6.0-RELEASE/swift-6.0-RELEASE-ubuntu22.04.tar.gz"
-              ;;
-            "6.1")
-              SWIFT_URL="https://download.swift.org/swift-6.1-release/ubuntu2204/swift-6.1-RELEASE/swift-6.1-RELEASE-ubuntu22.04.tar.gz"
-              ;;
-            *)
-              echo "Error: Unsupported Swift version."
-              exit 1
-              ;;
-          esac
-          
-          echo "Downloading Swift from $SWIFT_URL"
-          wget "$SWIFT_URL"
-          tar xzf "swift-${SWIFT_VERSION}-RELEASE-ubuntu22.04.tar.gz"
-          
-          export PATH="/home/runner/work/swift-${SWIFT_VERSION}-RELEASE-ubuntu22.04/usr/bin:$PATH"
-          
-          swift --version
-
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run SwiftPM tests
         run: swift test
+
+  # Single always-running umbrella check. Set this as the only required
+  # status check in branch protection so docs-only PRs (which skip the
+  # test jobs) can still merge. Renaming this job requires updating
+  # branch protection in the GitHub UI.
+  ci-required:
+    name: CI Required
+    needs: [test-apple-platforms, test-linux]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs did not fail or cancel
+        run: |
+          apple="${{ needs.test-apple-platforms.result }}"
+          linux="${{ needs.test-linux.result }}"
+          echo "test-apple-platforms: $apple"
+          echo "test-linux: $linux"
+          for r in "$apple" "$linux"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "Required job did not pass (result=$r)"; exit 1 ;;
+            esac
+          done


### PR DESCRIPTION
Restructure `.github/workflows/main.yml` into four jobs so that branch protection can rely on a single required check and docs-only PRs no longer trigger the full matrix.