### PR TITLE
Add MsgPackRawValue for deferred / pass-through decoding

### DIFF
--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -53,7 +53,7 @@ open class MsgPackDecoder {
 
     open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         try data.withUnsafeBytes {
-            let scanner: MsgPackScanner = .init(ptr: $0.baseAddress!, count: $0.count)
+            let scanner: MsgPackScanner = .init(source: data, ptr: $0.baseAddress!, count: $0.count)
             let value = scanRoot(scanner)
             let decoder: _MsgPackDecoder = .init(from: value)
             do {
@@ -70,7 +70,7 @@ open class MsgPackDecoder {
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T: DecodableWithConfiguration>(_ type: T.Type, from data: Data, configuration: T.DecodingConfiguration) throws -> T {
         try data.withUnsafeBytes {
-            let scanner: MsgPackScanner = .init(ptr: $0.baseAddress!, count: $0.count)
+            let scanner: MsgPackScanner = .init(source: data, ptr: $0.baseAddress!, count: $0.count)
             let value = scanRoot(scanner)
             let decoder: _MsgPackDecoder = .init(from: value)
             do {
@@ -100,10 +100,12 @@ public typealias MsgPackCodable = MsgPackDecodable & MsgPackEncodable
 private class _MsgPackDecoder: Decoder {
     var codingPath: [CodingKey]
     var value: MsgPackValue
+    let rawData: Data?
     var userInfo: [CodingUserInfoKey: Any] = [:]
 
     init(from value: MsgPackValue, at codingPath: [CodingKey] = []) {
-        self.value = value
+        rawData = value.rawData
+        self.value = value.stripped
         self.codingPath = codingPath
     }
 
@@ -139,6 +141,7 @@ private class _MsgPackDecoder: Decoder {
 
 private extension _MsgPackDecoder {
     func unbox(_ value: MsgPackValue, as type: Bool.Type) throws -> Bool? {
+        let value = value.stripped
         if case let .literal(value) = value {
             switch value {
             case let .bool(v): return v
@@ -155,6 +158,7 @@ private extension _MsgPackDecoder {
     }
 
     func unbox(_ value: MsgPackValue, as type: String.Type) throws -> String? {
+        let value = value.stripped
         if case let .literal(value) = value {
             switch value {
             case let .str(v):
@@ -173,6 +177,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxFloat32(_ value: MsgPackValue) throws -> Float? {
+        let value = value.stripped
         if case let .literal(f) = value {
             switch f {
             case let .float32(v):
@@ -193,6 +198,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxFloat64(_ value: MsgPackValue) throws -> Double? {
+        let value = value.stripped
         if case let .literal(f) = value {
             switch f {
             case let .float32(v):
@@ -213,6 +219,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxInt<T: SignedInteger & FixedWidthInteger>(_ value: MsgPackValue) throws -> T {
+        let value = value.stripped
         if case let .literal(vv) = value {
             switch vv {
             case let .uint(v), let .int(v):
@@ -229,6 +236,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxUInt<T: UnsignedInteger & FixedWidthInteger>(_ value: MsgPackValue) throws -> T {
+        let value = value.stripped
         if case let .literal(literal) = value {
             switch literal {
             case let .uint(v):
@@ -453,7 +461,7 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     }
 
     mutating func decodeNil() throws -> Bool {
-        let value = try getNextValue(ofType: Never.self)
+        let value = try getNextValue(ofType: Never.self).stripped
         if case .literal(.nil) = value {
             currentIndex += 1
             return true
@@ -697,7 +705,7 @@ private struct MsgPackKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContain
     }
 
     func decodeNil(forKey key: Key) throws -> Bool {
-        let value = try getValue(forKey: key)
+        let value = try getValue(forKey: key).stripped
         if case .literal(.nil) = value {
             return true
         } else {

--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -255,6 +255,15 @@ private extension _MsgPackDecoder {
 
 extension _MsgPackDecoder {
     func unwrap<T: Decodable>(as type: T.Type) throws -> T {
+        if type == MsgPackRawValue.self {
+            guard let d = rawData else {
+                throw DecodingError.dataCorrupted(.init(
+                    codingPath: codingPath,
+                    debugDescription: "MsgPackRawValue requires MsgPackDecoder."
+                ))
+            }
+            return MsgPackRawValue(d) as! T
+        }
         if type == Data.self || type == NSData.self {
             return try unwrapData() as! T
         }

--- a/Sources/SwiftMsgpack/MsgPackEncoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackEncoder.swift
@@ -455,6 +455,8 @@ private extension _SpecialTreatmentEncoder {
     func wrapEncodable<E: Encodable>(_ encodable: E, for additionalKey: CodingKey?) throws -> MsgPackEncodedValue? {
         let encoder = getEncoder(for: additionalKey)
         switch encodable {
+        case let raw as MsgPackRawValue:
+            return try wrapMsgPackRawValue(raw, for: additionalKey)
         case let data as Data:
             return try wrapData(data, for: additionalKey)
         case let msgPack as MsgPackEncodable:
@@ -478,6 +480,8 @@ private extension _SpecialTreatmentEncoder {
     func wrapEncodable<E: EncodableWithConfiguration>(_ encodable: E, configuration: E.EncodingConfiguration, for additionalKey: CodingKey?) throws -> MsgPackEncodedValue? {
         let encoder = getEncoder(for: additionalKey)
         switch encodable {
+        case let raw as MsgPackRawValue:
+            return try wrapMsgPackRawValue(raw, for: additionalKey)
         case let data as Data:
             return try wrapData(data, for: additionalKey)
         case let msgPack as MsgPackEncodable:
@@ -496,6 +500,22 @@ private extension _SpecialTreatmentEncoder {
             }
         }
         return encoder.value
+    }
+
+    func wrapMsgPackRawValue(_ raw: MsgPackRawValue, for additionalKey: CodingKey?) throws -> MsgPackEncodedValue {
+        guard !raw.data.isEmpty else {
+            let path: [CodingKey]
+            if let additionalKey = additionalKey {
+                path = codingPath + [additionalKey]
+            } else {
+                path = codingPath
+            }
+            throw EncodingError.invalidValue(raw, .init(
+                codingPath: path,
+                debugDescription: "MsgPackRawValue has empty data."
+            ))
+        }
+        return .literal([UInt8](raw.data))
     }
 
     func wrapData(_ data: Data, for additionalKey: CodingKey?) throws -> MsgPackEncodedValue {

--- a/Sources/SwiftMsgpack/MsgPackLazyValue.swift
+++ b/Sources/SwiftMsgpack/MsgPackLazyValue.swift
@@ -75,7 +75,7 @@ final class LazyMapCursor {
         consumedPairs += 1
         pairs.append((k, v))
         var keyString: String?
-        if case let .literal(.str(buf)) = k, let s = String._tryFromUTF8(buf) {
+        if case let .literal(.str(buf)) = k.stripped, let s = String._tryFromUTF8(buf) {
             if stringIndex[s] == nil {
                 stringIndex[s] = pairs.count - 1
             }

--- a/Sources/SwiftMsgpack/MsgPackRawValue.swift
+++ b/Sources/SwiftMsgpack/MsgPackRawValue.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct MsgPackRawValue: Hashable, Sendable {
+    public let data: Data
+
+    public init(_ data: Data) {
+        self.data = data
+    }
+}
+
+extension MsgPackRawValue: Codable {
+    public init(from decoder: Decoder) throws {
+        throw DecodingError.dataCorrupted(.init(
+            codingPath: decoder.codingPath,
+            debugDescription: "MsgPackRawValue can only be decoded via MsgPackDecoder."
+        ))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        throw EncodingError.invalidValue(self, .init(
+            codingPath: encoder.codingPath,
+            debugDescription: "MsgPackRawValue can only be encoded via MsgPackEncoder."
+        ))
+    }
+}

--- a/Sources/SwiftMsgpack/MsgPackScanner.swift
+++ b/Sources/SwiftMsgpack/MsgPackScanner.swift
@@ -261,14 +261,20 @@ enum MsgPackOpCode {
 }
 
 class MsgPackScanner {
+    private let source: Data
     private let start: UnsafeRawPointer
     private var ptr: UnsafeRawPointer
     private let count: Int
 
-    init(ptr: UnsafeRawPointer, count: Int) {
+    init(source: Data, ptr: UnsafeRawPointer, count: Int) {
+        self.source = source
         start = ptr
         self.ptr = ptr
         self.count = count
+    }
+
+    private func slice(from begin: Int, to end: Int) -> Data {
+        source.subdata(in: (source.startIndex + begin) ..< (source.startIndex + end))
     }
 
     private func advanced(by n: Int) {
@@ -310,6 +316,16 @@ class MsgPackScanner {
     }
 
     func scan() -> MsgPackValue {
+        let begin = start.distance(to: ptr)
+        let inner = scanInner()
+        let end = start.distance(to: ptr)
+        if end <= begin {
+            return inner
+        }
+        return .raw(slice(from: begin, to: end), inner)
+    }
+
+    private func scanInner() -> MsgPackValue {
         switch readOpCode() {
         case .end, .neverUsed:
             .none
@@ -438,6 +454,16 @@ extension MsgPackScanner {
     }
 
     func scanLazy() -> MsgPackValue {
+        let begin = start.distance(to: ptr)
+        let inner = scanLazyInner()
+        let end = start.distance(to: ptr)
+        if end <= begin {
+            return inner
+        }
+        return .raw(slice(from: begin, to: end), inner)
+    }
+
+    func scanLazyInner() -> MsgPackValue {
         switch readOpCode() {
         case .end, .neverUsed:
             return .none

--- a/Sources/SwiftMsgpack/MsgPackScanner.swift
+++ b/Sources/SwiftMsgpack/MsgPackScanner.swift
@@ -47,11 +47,30 @@ indirect enum MsgPackValue {
     case map([MsgPackValue])
     case lazyArray(LazyArrayCursor)
     case lazyMap(LazyMapCursor)
+    case raw(Data, MsgPackValue)
+}
+
+extension MsgPackValue {
+    var stripped: MsgPackValue {
+        if case let .raw(_, inner) = self {
+            return inner.stripped
+        }
+        return self
+    }
+
+    var rawData: Data? {
+        if case let .raw(d, _) = self {
+            return d
+        }
+        return nil
+    }
 }
 
 extension MsgPackValue {
     func asArray() -> [MsgPackValue] {
         switch self {
+        case let .raw(_, inner):
+            return inner.asArray()
         case .none:
             return []
         case .literal, .ext:
@@ -67,6 +86,8 @@ extension MsgPackValue {
 
     func asDictionary() -> [(MsgPackValue, MsgPackValue)] {
         switch self {
+        case let .raw(_, inner):
+            return inner.asDictionary()
         case .none, .literal, .ext:
             return []
         case let .array(a):
@@ -120,6 +141,8 @@ extension MsgPackValue {
 extension MsgPackValue {
     var debugDataTypeDescription: String {
         switch self {
+        case let .raw(_, inner):
+            return inner.debugDataTypeDescription
         case .none:
             return "none"
         case let .literal(v):

--- a/Tests/SwiftMsgpackTests/LazyDecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/LazyDecodeTests.swift
@@ -236,8 +236,8 @@ final class LazyDecodeTests: XCTestCase {
         let data = try encoder.encode(OrderedEntries(entries: entries))
 
         data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
-            let scanner = MsgPackScanner(ptr: raw.baseAddress!, count: raw.count)
-            guard case let .lazyMap(cursor) = scanner.scanLazy() else {
+            let scanner = MsgPackScanner(source: data, ptr: raw.baseAddress!, count: raw.count)
+            guard case let .lazyMap(cursor) = scanner.scanLazy().stripped else {
                 XCTFail("expected .lazyMap at root")
                 return
             }
@@ -266,8 +266,8 @@ final class LazyDecodeTests: XCTestCase {
         let data = try encoder.encode(arr)
 
         data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
-            let scanner = MsgPackScanner(ptr: raw.baseAddress!, count: raw.count)
-            guard case let .lazyArray(cursor) = scanner.scanLazy() else {
+            let scanner = MsgPackScanner(source: data, ptr: raw.baseAddress!, count: raw.count)
+            guard case let .lazyArray(cursor) = scanner.scanLazy().stripped else {
                 XCTFail("expected .lazyArray at root")
                 return
             }

--- a/Tests/SwiftMsgpackTests/MsgPackRawValueTests.swift
+++ b/Tests/SwiftMsgpackTests/MsgPackRawValueTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+@testable import SwiftMsgpack
+
+final class MsgPackRawValueTests: XCTestCase {
+    private let eager = MsgPackDecoder()
+    private let lazy = MsgPackDecoder(options: [.lazyScan])
+    private let encoder = MsgPackEncoder()
+
+    private func bothModes(_ body: (MsgPackDecoder, String) throws -> Void) rethrows {
+        try body(eager, "eager")
+        try body(lazy, "lazy")
+    }
+
+    // MARK: - Decoding
+
+    func testDecodeTopLevelBool() throws {
+        try bothModes { decoder, mode in
+            let raw = try decoder.decode(MsgPackRawValue.self, from: Data(hex: "c3"))
+            XCTAssertEqual(raw.data, Data([0xC3]), "mode: \(mode)")
+        }
+    }
+
+    func testDecodeTopLevelMap() throws {
+        try bothModes { decoder, mode in
+            let bytes = Data(hex: "82a15812a15934")
+            let raw = try decoder.decode(MsgPackRawValue.self, from: bytes)
+            XCTAssertEqual(raw.data, bytes, "mode: \(mode)")
+        }
+    }
+
+    func testDecodePayloadInEnvelopeForInt() throws {
+        let bytes = Data(hex: "82a46b696e64a3666f6fa77061796c6f61642a")
+        try bothModes { decoder, mode in
+            let env = try decoder.decode(Envelope.self, from: bytes)
+            XCTAssertEqual(env.kind, "foo", "mode: \(mode)")
+            XCTAssertEqual(env.payload.data, Data([0x2A]), "mode: \(mode)")
+        }
+    }
+
+    func testDecodePayloadInEnvelopeForString() throws {
+        let payloadStr = try encoder.encode("hello")
+        let bytes = try encoder.encode(["kind": "s", "payload": "hello"])
+        try bothModes { decoder, mode in
+            let env = try decoder.decode(Envelope.self, from: bytes)
+            XCTAssertEqual(env.payload.data, payloadStr, "mode: \(mode)")
+        }
+    }
+
+    func testDecodePayloadInEnvelopeForArray() throws {
+        let payload = [1, 2, 3]
+        let payloadBytes = try encoder.encode(payload)
+        let bytes = try encoder.encode(EnvelopeOf(kind: "a", payload: payload))
+        try bothModes { decoder, mode in
+            let env = try decoder.decode(Envelope.self, from: bytes)
+            XCTAssertEqual(env.payload.data, payloadBytes, "mode: \(mode)")
+        }
+    }
+
+    func testDecodePayloadInEnvelopeForMap() throws {
+        let payload: [String: Int] = ["x": 1, "y": 2]
+        let payloadBytes = try encoder.encode(payload)
+        let bytes = try encoder.encode(EnvelopeOf(kind: "m", payload: payload))
+        try bothModes { decoder, mode in
+            let env = try decoder.decode(Envelope.self, from: bytes)
+            let inner = try decoder.decode([String: Int].self, from: env.payload.data)
+            XCTAssertEqual(inner, payload, "mode: \(mode)")
+            XCTAssertEqual(env.payload.data, payloadBytes, "mode: \(mode)")
+        }
+    }
+
+    func testDecodePayloadInEnvelopeForExt() throws {
+        let ts = MsgPackTimestamp(seconds: 1, nanoseconds: 0)
+        let bytes = try encoder.encode(EnvelopeOf(kind: "t", payload: ts))
+        let tsBytes = try encoder.encode(ts)
+        try bothModes { decoder, mode in
+            let env = try decoder.decode(Envelope.self, from: bytes)
+            XCTAssertEqual(env.payload.data, tsBytes, "mode: \(mode)")
+            let decoded = try decoder.decode(MsgPackTimestamp.self, from: env.payload.data)
+            XCTAssertEqual(decoded, ts, "mode: \(mode)")
+        }
+    }
+
+    func testDecodeArrayOfRawValues() throws {
+        let bytes = Data(hex: "93c3c0a3666f6f")
+        try bothModes { decoder, mode in
+            let arr = try decoder.decode([MsgPackRawValue].self, from: bytes)
+            XCTAssertEqual(arr.count, 3, "mode: \(mode)")
+            XCTAssertEqual(arr[0].data, Data([0xC3]), "mode: \(mode)")
+            XCTAssertEqual(arr[1].data, Data([0xC0]), "mode: \(mode)")
+            XCTAssertEqual(arr[2].data, Data([0xA3, 0x66, 0x6F, 0x6F]), "mode: \(mode)")
+        }
+    }
+
+    func testDecodeMapOfRawValues() throws {
+        let bytes = Data(hex: "81a16bc3")
+        try bothModes { decoder, mode in
+            let dict = try decoder.decode([String: MsgPackRawValue].self, from: bytes)
+            XCTAssertEqual(dict["k"]?.data, Data([0xC3]), "mode: \(mode)")
+        }
+    }
+
+    // MARK: - Encoding
+
+    func testEncodeTopLevel() throws {
+        let raw = MsgPackRawValue(Data([0xC3]))
+        let bytes = try encoder.encode(raw)
+        XCTAssertEqual(bytes, Data([0xC3]))
+    }
+
+    func testEncodeKeyed() throws {
+        let payload = Data([0x2A])
+        let env = EnvelopeOf(kind: "foo", payload: MsgPackRawValue(payload))
+        let bytes = try encoder.encode(env)
+        let env2 = try eager.decode(Envelope.self, from: bytes)
+        XCTAssertEqual(env2.kind, "foo")
+        XCTAssertEqual(env2.payload.data, payload)
+    }
+
+    func testEncodeArray() throws {
+        let arr = [MsgPackRawValue(Data([0xC3])), MsgPackRawValue(Data([0xC2]))]
+        let bytes = try encoder.encode(arr)
+        XCTAssertEqual(bytes, Data([0x92, 0xC3, 0xC2]))
+    }
+
+    func testEncodeEmptyDataRejected() {
+        XCTAssertThrowsError(try encoder.encode(MsgPackRawValue(Data()))) { error in
+            guard case EncodingError.invalidValue = error else {
+                XCTFail("expected EncodingError.invalidValue, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Round trip
+
+    func testRoundTripInjectedPayload() throws {
+        let original = SamplePayload(n: 7, label: "lucky")
+        let prePayload = try encoder.encode(original)
+        let env = EnvelopeOf(kind: "sample", payload: MsgPackRawValue(prePayload))
+        let envBytes = try encoder.encode(env)
+
+        try bothModes { decoder, mode in
+            let envBack = try decoder.decode(Envelope.self, from: envBytes)
+            XCTAssertEqual(envBack.kind, "sample", "mode: \(mode)")
+            let payloadBack = try decoder.decode(SamplePayload.self, from: envBack.payload.data)
+            XCTAssertEqual(payloadBack, original, "mode: \(mode)")
+        }
+    }
+}
+
+private struct Envelope: Decodable, Equatable {
+    let kind: String
+    let payload: MsgPackRawValue
+}
+
+private struct EnvelopeOf<Payload: Encodable>: Encodable {
+    let kind: String
+    let payload: Payload
+}
+
+private struct SamplePayload: Codable, Equatable {
+    let n: Int
+    let label: String
+}
+
+private extension Unicode.Scalar {
+    var hexNibble: UInt8 {
+        let value = value
+        if value >= 48, value <= 57 {
+            return UInt8(value - 48)
+        } else if value >= 65, value <= 70 {
+            return UInt8(value - 55)
+        } else if value >= 97, value <= 102 {
+            return UInt8(value - 87)
+        }
+        fatalError("\(self) not a legal hex nibble")
+    }
+}
+
+private extension Data {
+    init(hex: String) {
+        let scalars = hex.unicodeScalars
+        var bytes = [UInt8](repeating: 0, count: (scalars.count + 1) >> 1)
+        for (index, scalar) in scalars.enumerated() {
+            var nibble = scalar.hexNibble
+            if index & 1 == 0 {
+                nibble <<= 4
+            }
+            bytes[index >> 1] |= nibble
+        }
+        self = Data(bytes)
+    }
+}


### PR DESCRIPTION
Add `MsgPackRawValue`, the MessagePack analogue of Go's `encoding/json.RawMessage`.