### PR TITLE
refactor: replace MsgPackValue raw wrappers with source ranges

### DIFF
--- a/Sources/SwiftMsgpack/MsgPackDecoder.swift
+++ b/Sources/SwiftMsgpack/MsgPackDecoder.swift
@@ -55,7 +55,7 @@ open class MsgPackDecoder {
         try data.withUnsafeBytes {
             let scanner: MsgPackScanner = .init(source: data, ptr: $0.baseAddress!, count: $0.count)
             let value = scanRoot(scanner)
-            let decoder: _MsgPackDecoder = .init(from: value)
+            let decoder: _MsgPackDecoder = .init(from: value, source: data)
             do {
                 return try decoder.unwrap(as: T.self)
             } catch {
@@ -72,7 +72,7 @@ open class MsgPackDecoder {
         try data.withUnsafeBytes {
             let scanner: MsgPackScanner = .init(source: data, ptr: $0.baseAddress!, count: $0.count)
             let value = scanRoot(scanner)
-            let decoder: _MsgPackDecoder = .init(from: value)
+            let decoder: _MsgPackDecoder = .init(from: value, source: data)
             do {
                 return try decoder.unwrap(as: T.self, configuration: configuration)
             } catch {
@@ -100,17 +100,25 @@ public typealias MsgPackCodable = MsgPackDecodable & MsgPackEncodable
 class _MsgPackDecoder: Decoder {
     var codingPath: [CodingKey]
     var value: MsgPackValue
-    let rawData: Data?
+    let source: Data
+    let byteRange: Range<Int>?
     var userInfo: [CodingUserInfoKey: Any] = [:]
 
-    init(from value: MsgPackValue, at codingPath: [CodingKey] = []) {
-        rawData = value.rawData
-        self.value = value.stripped
+    init(from value: MsgPackValue, source: Data, at codingPath: [CodingKey] = []) {
+        byteRange = value.byteRange
+        self.value = value
+        self.source = source
         self.codingPath = codingPath
     }
 
+    var rawData: Data? {
+        guard let r = byteRange else { return nil }
+        let s = source.startIndex
+        return source.subdata(in: s.advanced(by: r.lowerBound) ..< s.advanced(by: r.upperBound))
+    }
+
     func container<Key>(keyedBy _: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
-        switch value {
+        switch value.content {
         case .map, .lazyMap: break
         default:
             throw DecodingError.typeMismatch(
@@ -124,7 +132,7 @@ class _MsgPackDecoder: Decoder {
     }
 
     func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        switch value {
+        switch value.content {
         case .array, .map, .none, .lazyArray, .lazyMap: break
         default:
             throw DecodingError.typeMismatch(
@@ -145,8 +153,7 @@ class _MsgPackDecoder: Decoder {
 
 private extension _MsgPackDecoder {
     func unbox(_ value: MsgPackValue, as type: Bool.Type) throws -> Bool? {
-        let value = value.stripped
-        if case let .literal(value) = value {
+        if case let .literal(value) = value.content {
             switch value {
             case let .bool(v): return v
             case .nil: return nil
@@ -164,8 +171,7 @@ private extension _MsgPackDecoder {
     }
 
     func unbox(_ value: MsgPackValue, as type: String.Type) throws -> String? {
-        let value = value.stripped
-        if case let .literal(value) = value {
+        if case let .literal(value) = value.content {
             switch value {
             case let .str(v):
                 return String._tryFromUTF8(v)
@@ -185,8 +191,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxFloat32(_ value: MsgPackValue) throws -> Float? {
-        let value = value.stripped
-        if case let .literal(f) = value {
+        if case let .literal(f) = value.content {
             switch f {
             case let .float32(v):
                 return v
@@ -208,8 +213,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxFloat64(_ value: MsgPackValue) throws -> Double? {
-        let value = value.stripped
-        if case let .literal(f) = value {
+        if case let .literal(f) = value.content {
             switch f {
             case let .float32(v):
                 return Double(v)
@@ -231,8 +235,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxInt<T: SignedInteger & FixedWidthInteger>(_ value: MsgPackValue) throws -> T {
-        let value = value.stripped
-        if case let .literal(vv) = value {
+        if case let .literal(vv) = value.content {
             switch vv {
             case let .uint(v), let .int(v):
                 return T(truncatingIfNeeded: v)
@@ -250,8 +253,7 @@ private extension _MsgPackDecoder {
     }
 
     func unboxUInt<T: UnsignedInteger & FixedWidthInteger>(_ value: MsgPackValue) throws -> T {
-        let value = value.stripped
-        if case let .literal(literal) = value {
+        if case let .literal(literal) = value.content {
             switch literal {
             case let .uint(v):
                 return T(truncatingIfNeeded: v)
@@ -302,7 +304,7 @@ extension _MsgPackDecoder {
     }
 
     func unwrapData() throws -> Data {
-        switch value {
+        switch value.content {
         case let .literal(.bin(v)):
             v
         case let .literal(.str(v)):
@@ -313,7 +315,7 @@ extension _MsgPackDecoder {
     }
 
     func unwrapMsgPackDecodable(as type: MsgPackDecodable.Type) throws -> MsgPackDecodable {
-        guard case let .ext(typeNo, data) = value else {
+        guard case let .ext(typeNo, data) = value.content else {
             throw DecodingError.typeMismatch(MsgPackDecodable.self, DecodingError.Context(codingPath: codingPath, debugDescription: ""))
         }
         let value = try type.init(msgPack: data)
@@ -327,7 +329,7 @@ extension _MsgPackDecoder {
         guard (T.self as? (_MsgPackDictionaryDecodableMarker & Decodable).Type) != nil else {
             preconditionFailure("Must only be called of T implements _MsgPackDictionaryDecodableMarker")
         }
-        switch value {
+        switch value.content {
         case .map, .lazyMap: break
         default:
             throw DecodingError.typeMismatch(
@@ -343,7 +345,7 @@ extension _MsgPackDecoder {
         guard (T.self as? (_MsgPackArrayDecodableMarker & Decodable).Type) != nil else {
             preconditionFailure("Must only be called of T implements _MsgPackArrayDecodableMarker")
         }
-        switch value {
+        switch value.content {
         case .array, .lazyArray: break
         default:
             throw DecodingError.typeMismatch(
@@ -368,7 +370,7 @@ private struct _MsgPackSingleValueDecodingContainer: SingleValueDecodingContaine
     }
 
     func decodeNil() -> Bool {
-        if case .literal(.nil) = value {
+        if case .literal(.nil) = value.content {
             return true
         } else {
             return false
@@ -475,7 +477,7 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
         self.decoder = decoder
         codingPath = decoder.codingPath
         currentIndex = 0
-        if case let .lazyArray(c) = container {
+        if case let .lazyArray(c) = container.content {
             source = .lazy(c)
         } else {
             source = .eager(container.asArray())
@@ -491,8 +493,8 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     }
 
     mutating func decodeNil() throws -> Bool {
-        let value = try getNextValue(ofType: Never.self).stripped
-        if case .literal(.nil) = value {
+        let value = try getNextValue(ofType: Never.self)
+        if case .literal(.nil) = value.content {
             currentIndex += 1
             return true
         }
@@ -606,7 +608,7 @@ private struct MsgPackUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer 
     private mutating func decoderForNextElement<T>(ofType _: T.Type) throws -> _MsgPackDecoder {
         let value = try getNextValue(ofType: T.self)
         let newPath = codingPath + [MsgPackKey(index: currentIndex)]
-        return _MsgPackDecoder(from: value, at: newPath)
+        return _MsgPackDecoder(from: value, source: decoder.source, at: newPath)
     }
 
     @inline(__always)
@@ -719,7 +721,7 @@ private struct MsgPackKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContain
 
     init(referencing decoder: _MsgPackDecoder, container: MsgPackValue) {
         self.decoder = decoder
-        if case let .lazyMap(c) = container {
+        if case let .lazyMap(c) = container.content {
             source = .lazy(c)
         } else {
             source = .eager(Self.asDictionary(value: container, using: decoder))
@@ -736,8 +738,8 @@ private struct MsgPackKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContain
     }
 
     func decodeNil(forKey key: Key) throws -> Bool {
-        let value = try getValue(forKey: key).stripped
-        if case .literal(.nil) = value {
+        let value = try getValue(forKey: key)
+        if case .literal(.nil) = value.content {
             return true
         } else {
             return false
@@ -843,7 +845,7 @@ private struct MsgPackKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContain
     private func decoderForKey<LocalKey: CodingKey>(_ key: LocalKey) throws -> _MsgPackDecoder {
         let value = try getValue(forKey: key)
         let newPath: [CodingKey] = codingPath + [key]
-        return _MsgPackDecoder(from: value, at: newPath)
+        return _MsgPackDecoder(from: value, source: decoder.source, at: newPath)
     }
 
     @inline(__always)

--- a/Sources/SwiftMsgpack/MsgPackLazyValue.swift
+++ b/Sources/SwiftMsgpack/MsgPackLazyValue.swift
@@ -75,7 +75,7 @@ final class LazyMapCursor {
         consumedPairs += 1
         pairs.append((k, v))
         var keyString: String?
-        if case let .literal(.str(buf)) = k.stripped, let s = String._tryFromUTF8(buf) {
+        if case let .literal(.str(buf)) = k.content, let s = String._tryFromUTF8(buf) {
             if stringIndex[s] == nil {
                 stringIndex[s] = pairs.count - 1
             }

--- a/Sources/SwiftMsgpack/MsgPackScanner.swift
+++ b/Sources/SwiftMsgpack/MsgPackScanner.swift
@@ -39,38 +39,39 @@ struct MsgPackStringKey {
     let msgPackValue: MsgPackEncodedValue
 }
 
-indirect enum MsgPackValue {
-    case none
-    case literal(MsgPackValueLiteralType)
-    case ext(Int8, Data)
-    case array([MsgPackValue])
-    case map([MsgPackValue])
-    case lazyArray(LazyArrayCursor)
-    case lazyMap(LazyMapCursor)
-    case raw(Data, MsgPackValue)
+struct MsgPackValue {
+    let content: Content
+    let byteRange: Range<Int>?
+
+    enum Content {
+        case none
+        case literal(MsgPackValueLiteralType)
+        case ext(Int8, Data)
+        case array([MsgPackValue])
+        case map([MsgPackValue])
+        case lazyArray(LazyArrayCursor)
+        case lazyMap(LazyMapCursor)
+    }
+
+    init(content: Content, byteRange: Range<Int>? = nil) {
+        self.content = content
+        self.byteRange = byteRange
+    }
 }
 
 extension MsgPackValue {
-    var stripped: MsgPackValue {
-        if case let .raw(_, inner) = self {
-            return inner.stripped
-        }
-        return self
-    }
-
-    var rawData: Data? {
-        if case let .raw(d, _) = self {
-            return d
-        }
-        return nil
-    }
+    static var none: MsgPackValue { .init(content: .none) }
+    static func literal(_ lit: MsgPackValueLiteralType) -> MsgPackValue { .init(content: .literal(lit)) }
+    static func ext(_ type: Int8, _ data: Data) -> MsgPackValue { .init(content: .ext(type, data)) }
+    static func array(_ a: [MsgPackValue]) -> MsgPackValue { .init(content: .array(a)) }
+    static func map(_ a: [MsgPackValue]) -> MsgPackValue { .init(content: .map(a)) }
+    static func lazyArray(_ c: LazyArrayCursor) -> MsgPackValue { .init(content: .lazyArray(c)) }
+    static func lazyMap(_ c: LazyMapCursor) -> MsgPackValue { .init(content: .lazyMap(c)) }
 }
 
 extension MsgPackValue {
     func asArray() -> [MsgPackValue] {
-        switch self {
-        case let .raw(_, inner):
-            return inner.asArray()
+        switch content {
         case .none:
             return []
         case .literal, .ext:
@@ -85,9 +86,7 @@ extension MsgPackValue {
     }
 
     func asDictionary() -> [(MsgPackValue, MsgPackValue)] {
-        switch self {
-        case let .raw(_, inner):
-            return inner.asDictionary()
+        switch content {
         case .none, .literal, .ext:
             return []
         case let .array(a):
@@ -140,9 +139,7 @@ extension MsgPackValue {
 
 extension MsgPackValue {
     var debugDataTypeDescription: String {
-        switch self {
-        case let .raw(_, inner):
-            return inner.debugDataTypeDescription
+        switch content {
         case .none:
             return "none"
         case let .literal(v):
@@ -273,10 +270,6 @@ class MsgPackScanner {
         self.count = count
     }
 
-    private func slice(from begin: Int, to end: Int) -> Data {
-        source.subdata(in: (source.startIndex + begin) ..< (source.startIndex + end))
-    }
-
     private func advanced(by n: Int) {
         ptr = ptr.advanced(by: n)
     }
@@ -322,7 +315,7 @@ class MsgPackScanner {
         if end <= begin {
             return inner
         }
-        return .raw(slice(from: begin, to: end), inner)
+        return MsgPackValue(content: inner.content, byteRange: begin ..< end)
     }
 
     private func scanInner() -> MsgPackValue {
@@ -460,7 +453,7 @@ extension MsgPackScanner {
         if end <= begin {
             return inner
         }
-        return .raw(slice(from: begin, to: end), inner)
+        return MsgPackValue(content: inner.content, byteRange: begin ..< end)
     }
 
     func scanLazyInner() -> MsgPackValue {

--- a/Tests/SwiftMsgpackTests/LazyDecodeTests.swift
+++ b/Tests/SwiftMsgpackTests/LazyDecodeTests.swift
@@ -237,7 +237,7 @@ final class LazyDecodeTests: XCTestCase {
 
         data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
             let scanner = MsgPackScanner(source: data, ptr: raw.baseAddress!, count: raw.count)
-            guard case let .lazyMap(cursor) = scanner.scanLazy().stripped else {
+            guard case let .lazyMap(cursor) = scanner.scanLazy().content else {
                 XCTFail("expected .lazyMap at root")
                 return
             }
@@ -267,7 +267,7 @@ final class LazyDecodeTests: XCTestCase {
 
         data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
             let scanner = MsgPackScanner(source: data, ptr: raw.baseAddress!, count: raw.count)
-            guard case let .lazyArray(cursor) = scanner.scanLazy().stripped else {
+            guard case let .lazyArray(cursor) = scanner.scanLazy().content else {
                 XCTFail("expected .lazyArray at root")
                 return
             }

--- a/Tests/SwiftMsgpackTests/MsgPackRawValueTests.swift
+++ b/Tests/SwiftMsgpackTests/MsgPackRawValueTests.swift
@@ -117,6 +117,32 @@ final class MsgPackRawValueTests: XCTestCase {
         }
     }
 
+    func testDecodeAdjacentHeterogeneousRawValuesPreservesExactRanges() throws {
+        let bytes = Data(hex: "952ad903666f6fc40300ff7f92c381a16bc081a17893010203")
+        let expected = [
+            Data(hex: "2a"),
+            Data(hex: "d903666f6f"),
+            Data(hex: "c40300ff7f"),
+            Data(hex: "92c381a16bc0"),
+            Data(hex: "81a17893010203"),
+        ]
+
+        try bothModes { decoder, mode in
+            let values = try decoder.decode([MsgPackRawValue].self, from: bytes)
+            XCTAssertEqual(values.map(\.data), expected, "mode: \(mode)")
+        }
+    }
+
+    func testDecodeRawValuesAfterLazyMapReverseLookupPreservesExactRanges() throws {
+        let bytes = Data(hex: "82a161d9036f6e65a16292c3c0")
+
+        try bothModes { decoder, mode in
+            let value = try decoder.decode(ReverseRawEnvelope.self, from: bytes)
+            XCTAssertEqual(value.a.data, Data(hex: "d9036f6e65"), "mode: \(mode)")
+            XCTAssertEqual(value.b.data, Data(hex: "92c3c0"), "mode: \(mode)")
+        }
+    }
+
     // Foundation's DecodableWithConfiguration conformances for Array/Optional call the
     // element's init directly as `T(from: superDecoder(), configuration:)`, bypassing the
     // special casing in _MsgPackDecoder.unwrap(as:). Verifies that init(from:) itself can
@@ -227,6 +253,22 @@ final class MsgPackRawValueTests: XCTestCase {
             let payloadBack = try decoder.decode(SamplePayload.self, from: envBack.payload.data)
             XCTAssertEqual(payloadBack, original, "mode: \(mode)")
         }
+    }
+}
+
+private struct ReverseRawEnvelope: Decodable {
+    let a: MsgPackRawValue
+    let b: MsgPackRawValue
+
+    enum CodingKeys: String, CodingKey {
+        case a
+        case b
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        b = try container.decode(MsgPackRawValue.self, forKey: .b)
+        a = try container.decode(MsgPackRawValue.self, forKey: .a)
     }
 }
 


### PR DESCRIPTION
`MsgPackScanner.scan()` and `scanLazy()` previously wrapped every decoded node in `.raw(Data, inner)`, eagerly materializing a `Data.subdata` slice even though raw bytes are only needed when decoding `MsgPackRawValue`. Replace `MsgPackValue` with a struct that stores decoded content and its source byte range, retain the original source data in the decoder, and materialize raw data only on demand. This removes indirect boxing and eager slicing while preserving eager and lazy decode behavior and exact raw-value ranges. 